### PR TITLE
feat: Add Users-Chat link to sidebar

### DIFF
--- a/_includes/_sidebar.md
+++ b/_includes/_sidebar.md
@@ -1,2 +1,3 @@
 * [Aliases](./alias.html)
 * [Drive Items](./drive_items.html)
+* [Users Chat](./Users-Chat.html)


### PR DESCRIPTION
Added a reference to Users-Chat.md in the _includes/_sidebar.md file. The link follows the existing format and is added to the list of navigation items.